### PR TITLE
Add mcc mnc constant value

### DIFF
--- a/src/main/java/net/voldrich/smscsim/server/FailedDeliveryReceiptRecord.java
+++ b/src/main/java/net/voldrich/smscsim/server/FailedDeliveryReceiptRecord.java
@@ -61,6 +61,8 @@ public class FailedDeliveryReceiptRecord extends DeliveryReceiptRecord {
             SmppPduUtils.convertOptionalStringToCOctet(getMessageId())));
     pdu0.addOptionalParameter(
         new Tlv(SmppConstants.TAG_MSG_STATE, new byte[] {SmppConstants.STATE_DELIVERED}));
+    pdu0.addOptionalParameter(new Tlv(MccMncUtils.TAG_MCC_MNC,
+        SmppPduUtils.convertOptionalStringToCOctet(MccMncUtils.SIMULATOR_MCC_MNC_VALUE)));
 
     pdu0.calculateAndSetCommandLength();
 

--- a/src/main/java/net/voldrich/smscsim/server/FailedDeliveryReceiptRecord.java
+++ b/src/main/java/net/voldrich/smscsim/server/FailedDeliveryReceiptRecord.java
@@ -61,8 +61,8 @@ public class FailedDeliveryReceiptRecord extends DeliveryReceiptRecord {
             SmppPduUtils.convertOptionalStringToCOctet(getMessageId())));
     pdu0.addOptionalParameter(
         new Tlv(SmppConstants.TAG_MSG_STATE, new byte[] {SmppConstants.STATE_DELIVERED}));
-    pdu0.addOptionalParameter(new Tlv(MccMncUtils.TAG_MCC_MNC,
-        SmppPduUtils.convertOptionalStringToCOctet(MccMncUtils.SIMULATOR_MCC_MNC_VALUE)));
+
+    pdu0.addOptionalParameter(MccMncUtils.getSimulatorMccMncTlv());
 
     pdu0.calculateAndSetCommandLength();
 

--- a/src/main/java/net/voldrich/smscsim/server/MccMncUtils.java
+++ b/src/main/java/net/voldrich/smscsim/server/MccMncUtils.java
@@ -4,10 +4,10 @@ public class MccMncUtils {
 
   // TODO: Get from config/env
   private final static String GATEWAY_SERVICE_TLV_TAG = "1400";
-  private final static String MOBILE_COUNTRY_CODE = "63";
-  private final static String MOBILE_NETWORK_CODE = "0998";
+  private final static String COUNTRY_CODE = "63";
+  private final static String NETWORK_CODE = "0998";
 
   public final static short TAG_MCC_MNC = Short.parseShort(GATEWAY_SERVICE_TLV_TAG.trim(), 16);
-  public final static String SIMULATOR_MCC_MNC_VALUE = MOBILE_COUNTRY_CODE + MOBILE_NETWORK_CODE;
+  public final static String SIMULATOR_MCC_MNC_VALUE = COUNTRY_CODE + NETWORK_CODE;
 
 }

--- a/src/main/java/net/voldrich/smscsim/server/MccMncUtils.java
+++ b/src/main/java/net/voldrich/smscsim/server/MccMncUtils.java
@@ -6,7 +6,6 @@ import com.cloudhopper.smpp.tlv.Tlv;
 
 public class MccMncUtils {
 
-  // TODO: Get from config/env
   private final static String GATEWAY_SERVICE_MCC_MNC_TLV_TAG = "0x1400";
   private final static String COUNTRY_CODE = "123";
   private final static String NETWORK_CODE = "546";

--- a/src/main/java/net/voldrich/smscsim/server/MccMncUtils.java
+++ b/src/main/java/net/voldrich/smscsim/server/MccMncUtils.java
@@ -4,8 +4,8 @@ public class MccMncUtils {
 
   // TODO: Get from config/env
   private final static String GATEWAY_SERVICE_TLV_TAG = "1400";
-  private final static String COUNTRY_CODE = "63";
-  private final static String NETWORK_CODE = "0998";
+  private final static String COUNTRY_CODE = "123";
+  private final static String NETWORK_CODE = "546";
 
   public final static short TAG_MCC_MNC = Short.parseShort(GATEWAY_SERVICE_TLV_TAG.trim(), 16);
   public final static String SIMULATOR_MCC_MNC_VALUE = COUNTRY_CODE + NETWORK_CODE;

--- a/src/main/java/net/voldrich/smscsim/server/MccMncUtils.java
+++ b/src/main/java/net/voldrich/smscsim/server/MccMncUtils.java
@@ -3,11 +3,11 @@ package net.voldrich.smscsim.server;
 public class MccMncUtils {
 
   // TODO: Get from config/env
-  private final static String GATEWAY_SERVICE_TLV_TAG = "1400";
+  private final static String GATEWAY_SERVICE_TLV_TAG = "0x1400";
   private final static String COUNTRY_CODE = "123";
   private final static String NETWORK_CODE = "546";
 
-  public final static short TAG_MCC_MNC = Short.parseShort(GATEWAY_SERVICE_TLV_TAG.trim(), 16);
+  public final static short TAG_MCC_MNC = Short.decode(GATEWAY_SERVICE_TLV_TAG.trim());
   public final static String SIMULATOR_MCC_MNC_VALUE = COUNTRY_CODE + NETWORK_CODE;
 
 }

--- a/src/main/java/net/voldrich/smscsim/server/MccMncUtils.java
+++ b/src/main/java/net/voldrich/smscsim/server/MccMncUtils.java
@@ -1,0 +1,13 @@
+package net.voldrich.smscsim.server;
+
+public class MccMncUtils {
+
+  // TODO: Get from config/env
+  private final static String GATEWAY_SERVICE_TLV_TAG = "1400";
+  private final static String MOBILE_COUNTRY_CODE = "63";
+  private final static String MOBILE_NETWORK_CODE = "0998";
+
+  public final static short TAG_MCC_MNC = Short.parseShort(GATEWAY_SERVICE_TLV_TAG.trim(), 16);
+  public final static String SIMULATOR_MCC_MNC_VALUE = MOBILE_COUNTRY_CODE + MOBILE_NETWORK_CODE;
+
+}

--- a/src/main/java/net/voldrich/smscsim/server/MccMncUtils.java
+++ b/src/main/java/net/voldrich/smscsim/server/MccMncUtils.java
@@ -1,13 +1,23 @@
 package net.voldrich.smscsim.server;
 
+import static net.voldrich.smscsim.server.SmppPduUtils.convertOptionalStringToCOctet;
+
+import com.cloudhopper.smpp.tlv.Tlv;
+
 public class MccMncUtils {
 
   // TODO: Get from config/env
-  private final static String GATEWAY_SERVICE_TLV_TAG = "0x1400";
+  private final static String GATEWAY_SERVICE_MCC_MNC_TLV_TAG = "0x1400";
   private final static String COUNTRY_CODE = "123";
   private final static String NETWORK_CODE = "546";
 
-  public final static short TAG_MCC_MNC = Short.decode(GATEWAY_SERVICE_TLV_TAG.trim());
-  public final static String SIMULATOR_MCC_MNC_VALUE = COUNTRY_CODE + NETWORK_CODE;
+  private final static short TAG_MCC_MNC = Short.decode(GATEWAY_SERVICE_MCC_MNC_TLV_TAG.trim());
+  private final static String SIMULATOR_MCC_MNC_VALUE = COUNTRY_CODE + NETWORK_CODE;
+
+  public final static Tlv simulatorMccMncTlv = new Tlv(TAG_MCC_MNC, convertOptionalStringToCOctet(SIMULATOR_MCC_MNC_VALUE));
+
+  public static Tlv getSimulatorMccMncTlv() {
+    return simulatorMccMncTlv;
+  }
 
 }

--- a/src/main/java/net/voldrich/smscsim/server/SmppPduUtils.java
+++ b/src/main/java/net/voldrich/smscsim/server/SmppPduUtils.java
@@ -56,8 +56,8 @@ public class SmppPduUtils {
                 deliveryReceiptRecord.getMessageId())));
     pdu0.addOptionalParameter(
         new Tlv(SmppConstants.TAG_MSG_STATE, new byte[] {SmppConstants.STATE_DELIVERED}));
-    pdu0.addOptionalParameter(new Tlv(MccMncUtils.TAG_MCC_MNC,
-        SmppPduUtils.convertOptionalStringToCOctet(MccMncUtils.SIMULATOR_MCC_MNC_VALUE)));
+
+    pdu0.addOptionalParameter(MccMncUtils.getSimulatorMccMncTlv());
 
     pdu0.calculateAndSetCommandLength();
 

--- a/src/main/java/net/voldrich/smscsim/server/SmppPduUtils.java
+++ b/src/main/java/net/voldrich/smscsim/server/SmppPduUtils.java
@@ -56,6 +56,8 @@ public class SmppPduUtils {
                 deliveryReceiptRecord.getMessageId())));
     pdu0.addOptionalParameter(
         new Tlv(SmppConstants.TAG_MSG_STATE, new byte[] {SmppConstants.STATE_DELIVERED}));
+    pdu0.addOptionalParameter(new Tlv(MccMncUtils.TAG_MCC_MNC,
+        SmppPduUtils.convertOptionalStringToCOctet(MccMncUtils.SIMULATOR_MCC_MNC_VALUE)));
 
     pdu0.calculateAndSetCommandLength();
 


### PR DESCRIPTION
### Changes
- add additional params returned by simulator
- return new params containing tlv_tag expected by gateway-service
- new param returns constant mccmnc as an identifier its from simulator

### Test
- Run all services
- Send a request in outbound
- Check gateway database
```
select count(*) as count, data -> 'payload' -> 'mccMnc' as mccMnc from gateway.gateway_event where data ->> 'type' = 'DeliveryResultReceived' group by data->'payload'->'mccMnc' order by count desc;
```
- Should return mccmnc value with count
```
 count |  mccmnc  
-------+-----------
    78 | "123546"
```
